### PR TITLE
Change link-to organization.

### DIFF
--- a/ember/app/templates/application.hbs
+++ b/ember/app/templates/application.hbs
@@ -1,7 +1,7 @@
 <h2 id='title'>Welcome to Boston Ember</h2>
 
-{{link-to 'Home' 'application'}}
-{{link-to 'About' 'about'}}
-{{link-to 'Speakers' 'speakers'}}
+{{#link-to 'application'}}Home{{/link-to}}
+{{#link-to 'about'}}About{{/link-to}}
+{{#link-to 'speakers'}}Speakers{{/link-to}}
 
 {{outlet}}


### PR DESCRIPTION
This is optional change of link-to routes. It does not change the behavior of link-to. 
However I think this is easier to distinguish which element is name of route and which is actual route. This pattern follows the convention of guides.emberjs.com.